### PR TITLE
Fix nginx authentication setup prompt

### DIFF
--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -496,7 +496,7 @@ nginx_setup() {
   if openhab3_is_installed || (whiptail --title "Authentication setup" --yesno "Would you like to secure your openHAB interface with username and password?" 7 80); then
     auth="true"
   fi
-  if [[ "$auth" == "yes" ]]; then
+  if [[ "$auth" == "true" ]]; then
     if nginxUsername="$(whiptail --title "Authentication setup" --inputbox "\\nEnter a username to sign into openHAB:" 9 80 openhab 3>&1 1>&2 2>&3)"; then
       while [[ -z $nginxPass ]]; do
         if ! nginxPass1="$(whiptail --title "Authentication setup" --passwordbox "\\nEnter a password for ${nginxUsername}:" 9 80 3>&1 1>&2 2>&3)"; then echo "CANCELED"; return 0; fi


### PR DESCRIPTION
Prompt for username and password did not show up because `$auth` was checked for `"yes"` instead of `"true"` ([set 2 lines before](https://github.com/No3x/openhabian/commit/d39383f173c8e8bff587a16de454a4096cc3f45e#diff-6db4f5084cdcf651cf5b9f8eb2265f3d5b46e1140997e4c83c588aa6df338f27L497)).